### PR TITLE
Helm deployment - Move to vLLM and use vault instead of secrets

### DIFF
--- a/.github/workflows/helmlint.yml
+++ b/.github/workflows/helmlint.yml
@@ -17,10 +17,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Create symlink to dummy service file
-      run: |
-        ln -s ../../../tests/helmlint/dummy-service.json cloud/helm/knowledgebase-slackbot/service.json
-
     - name: Download dependencies
       run: |
         helm dependency build cloud/helm/knowledgebase-slackbot

--- a/Containerfile
+++ b/Containerfile
@@ -23,6 +23,9 @@ FROM registry.fedoraproject.org/fedora:39 as runtime
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
 
+RUN dnf install --nodocs -y jq && \
+    dnf clean all -y
+
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 COPY knowledge_base_gpt/ ./knowledge_base_gpt

--- a/cloud/helm/README.md
+++ b/cloud/helm/README.md
@@ -1,14 +1,9 @@
 # Running the Slackbot on Kubernetes
 
-## Prerequisites
-The Helm chart assumes that [Certificate Manager](https://cert-manager.io/) is installed in the cluster
-
 ## Create the values file `myvals.yaml`
 ```yaml
-ingestFolderID: < The ID of the Google Folder used to ingestion >
-forwardChannel: < Name of the Channel to forward unanswered questions to >
-slackAppToken: < Slack App token, starts with xapp >
-slackBotToken: < Slack Bot token, starts with xoxb >
+vaultServerConfigMap: "vault-server-details"
+vaultCredentialsSecret: "vault-server-credentials"
 ```
 
 ## Install the chart

--- a/cloud/helm/knowledgebase-slackbot/Chart.yaml
+++ b/cloud/helm/knowledgebase-slackbot/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.1.1"
 
 keywords:
 - slackbot

--- a/cloud/helm/knowledgebase-slackbot/templates/_helpers.tpl
+++ b/cloud/helm/knowledgebase-slackbot/templates/_helpers.tpl
@@ -51,13 +51,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Proxy Certificate secret name
-*/}}
-{{- define "knowledgebase-slackbot.proxy-certificate-secret" -}}
-{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "certificate" }}
-{{- end }}
-
-{{/*
 Embedding DB Volume name
 */}}
 {{- define "knowledgebase-slackbot.embedding-pvc" -}}
@@ -79,38 +72,10 @@ Ingest Job name
 {{- end }}
 
 {{/*
-Service JSON secret name
-*/}}
-{{- define "knowledgebase-slackbot.service-json-secret" -}}
-{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "service-json" }}
-{{- end }}
-
-{{/*
-Ingest Folder ID secret name
-*/}}
-{{- define "knowledgebase-slackbot.folder-id-secret" -}}
-{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "folder-id" }}
-{{- end }}
-
-{{/*
 Logs Volume name
 */}}
 {{- define "knowledgebase-slackbot.logs-pvc" -}}
 {{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "logs" }}
-{{- end }}
-
-{{/*
-Forward Channel secret name
-*/}}
-{{- define "knowledgebase-slackbot.forward-channel-secret" -}}
-{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "forward-channel" }}
-{{- end }}
-
-{{/*
-Slack Tokens secret name
-*/}}
-{{- define "knowledgebase-slackbot.slackbot-tokens-secret" -}}
-{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "slackbot-tokens" }}
 {{- end }}
 
 {{/*
@@ -153,8 +118,15 @@ MetricBeat Pod name
 {{- end }}
 
 {{/*
-OpenAI or vLLM API Token secret name
+vLLM Cache Volume name
 */}}
-{{- define "knowledgebase-slackbot.openai-secret" -}}
-{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "openai" }}
+{{- define "knowledgebase-slackbot.vllm-pvc" -}}
+{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "vllm-cache" }}
+{{- end }}
+
+{{/*
+vLLM Deployment name
+*/}}
+{{- define "knowledgebase-slackbot.vllm-deployment-name" -}}
+{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "vllm" }}
 {{- end }}

--- a/cloud/helm/knowledgebase-slackbot/templates/_knowledgebase-config.tpl
+++ b/cloud/helm/knowledgebase-slackbot/templates/_knowledgebase-config.tpl
@@ -17,6 +17,8 @@ slackbot:
 llm:
   mode: vllm
 
+ollama: {}
+
 history:
   mode: redis
 

--- a/cloud/helm/knowledgebase-slackbot/templates/_vault.tpl
+++ b/cloud/helm/knowledgebase-slackbot/templates/_vault.tpl
@@ -1,0 +1,175 @@
+{{/*
+Init container to fetch secrets from Vault
+*/}}
+{{- define "knowledgebase-slackbot.vault-init-container" -}}
+- name: vault
+  image: docker.io/hashicorp/vault:latest
+  args:
+  - "agent"
+  - "-config=/vault/config/vault.hcl"
+  volumeMounts:
+  - name: vault-output
+    mountPath: /vault-output
+    readOnly: false
+  - name: vault-credentials
+    mountPath: /etc/vault-creds
+    readOnly: true
+  - name: vault-agent-config
+    mountPath: /vault/config
+    readOnly: true
+  - name: vault-template
+    mountPath: /vault/template
+    readOnly: true
+  - name: vault-ca-cert
+    mountPath: /etc/vault-ca
+    readOnly: true
+  env:
+  - name: SKIP_SETCAP
+    value: "true"
+  - name: VAULT_ADDR
+    valueFrom:
+      configMapKeyRef:
+        name: {{ required "vaultServerConfigMap must be set" .Values.vaultServerConfigMap }}
+        key: address
+  - name: VAULT_CACERT
+    value: "/etc/vault-ca/ca.crt"
+{{- end }}
+
+
+{{/*
+List of volumes added to Pod spec for Vault
+*/}}
+{{- define "knowledgebase-slackbot.vault-volumes" -}}
+- name: vault-output
+  emptyDir:
+    medium: Memory
+    sizeLimit: 10Mi
+- name: vault-ca-cert
+  configMap:
+    name: {{ required "vaultServerConfigMap must be set" .root.Values.vaultServerConfigMap }}
+    items:
+    - key: ca.crt
+      path: ca.crt
+- name: vault-credentials
+  secret:
+    secretName: {{ required "vaultCredentialsSecret must be set" .root.Values.vaultCredentialsSecret }}
+- name: vault-agent-config
+  configMap:
+    name: {{ printf "%s" (include "knowledgebase-slackbot.vault-agent-config-configmap" .root) }}
+- name: vault-template
+  configMap:
+    name: {{ .configMapName }}
+{{- end }}
+
+{{/*
+Vault Agent configuration ConfigMap Name
+*/}}
+{{- define "knowledgebase-slackbot.vault-agent-config-configmap" -}}
+{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "vault-agent-config" }}
+{{- end }}
+
+{{/*
+Vault Agent config
+*/}}
+{{- define "knowledgebase-slackbot.vault-agent-config" -}}
+exit_after_auth = true
+pid_file = "/tmp/pidfile"
+
+auto_auth {
+  method "approle" {
+    mount_path = "auth/approle"
+    config = {
+      role_id_file_path = "/etc/vault-creds/role-id"
+      secret_id_file_path = "/etc/vault-creds/secret-id"
+      remove_secret_id_file_after_reading = false
+    }
+  }
+
+  sink "file" {
+    config = {
+      path = "/tmp/vault-token-via-agent"
+      mode = 0644
+    }
+  }
+}
+
+cache {
+  use_auto_auth_token = true
+}
+
+listener "tcp" {
+  address = "127.0.0.1:8200"
+  tls_disable = true
+}
+
+template {
+  source      = "/vault/template/vars.env.tmpl"
+  destination = "/vault-output/vars.env"
+}
+{{- end }}
+
+{{/*
+Vault Template for Slackbot ConfigMap Name
+*/}}
+{{- define "knowledgebase-slackbot.vault-template-slackbot-configmap" -}}
+{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "vault-template-slackbot-configmap" }}
+{{- end }}
+
+{{/*
+Vault Template for Slackbot
+*/}}
+{{- define "knowledgebase-slackbot.vault-template-slackbot" -}}
+{{`
+  {{- with secret "apps/cloud-marketplace-chatbot-admin/huggingface" }}
+  export HUGGING_FACE_HUB_TOKEN='{{ .Data.data.token }}'
+  {{ end }}
+  {{- with secret "apps/cloud-marketplace-chatbot-admin/vllm" }}
+  export OPENAI_API_KEY='{{ .Data.data.token }}'
+  {{ end }}
+  {{- with secret "apps/cloud-marketplace-chatbot-admin/slackbot" }}
+  export SLACK_APP_TOKEN='{{ .Data.data.app_token }}'
+  export SLACK_BOT_TOKEN='{{ .Data.data.bot_token }}'
+  export FORWARD_QUESTION_CHANNEL_NAME='{{ .Data.data.forward_channel }}'
+  {{ end }}
+`}}
+{{- end }}
+
+{{/*
+Vault Template for vLLM ConfigMap Name
+*/}}
+{{- define "knowledgebase-slackbot.vault-template-vllm-configmap" -}}
+{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "vault-template-vllm-configmap" }}
+{{- end }}
+
+{{/*
+Vault Template for vLLM
+*/}}
+{{- define "knowledgebase-slackbot.vault-template-vllm" -}}
+{{`
+  {{- with secret "apps/cloud-marketplace-chatbot-admin/huggingface" }}
+  export HUGGING_FACE_HUB_TOKEN='{{ .Data.data.token }}'
+  {{ end }}
+  {{- with secret "apps/cloud-marketplace-chatbot-admin/vllm" }}
+  export VLLM_APP_TOKEN='{{ .Data.data.token }}'
+  {{ end }}
+`}}
+{{- end }}
+
+{{/*
+Vault Template for Ingest ConfigMap Name
+*/}}
+{{- define "knowledgebase-slackbot.vault-template-ingest-configmap" -}}
+{{- printf "%s-%s" (include "knowledgebase-slackbot.fullname" .) "vault-template-ingest-configmap" }}
+{{- end }}
+
+{{/*
+Vault Template for Ingest
+*/}}
+{{- define "knowledgebase-slackbot.vault-template-ingest" -}}
+{{`
+  {{- with secret "apps/cloud-marketplace-chatbot-admin/google_drive" }}
+  export GOOGLE_DRIVE_FOLDER_ID='{{ .Data.data.ingest_folder_id }}'
+  export SERVICE_JSON='{{ .Data.data.service_json }}'
+  {{ end }}
+`}}
+{{- end }}

--- a/cloud/helm/knowledgebase-slackbot/templates/forward-channel-secret.yaml
+++ b/cloud/helm/knowledgebase-slackbot/templates/forward-channel-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "knowledgebase-slackbot.forward-channel-secret" . }}
-type: Opaque
-data:
-  channel: {{ (required "Slack Question Forward Channel must be set" .Values.forwardChannel) | b64enc }}

--- a/cloud/helm/knowledgebase-slackbot/templates/ingest-folder-id-secret.yaml
+++ b/cloud/helm/knowledgebase-slackbot/templates/ingest-folder-id-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "knowledgebase-slackbot.folder-id-secret" . }}
-type: Opaque
-data:
-  folder-id: {{ (required "Google Folder ID must be set" .Values.ingestFolderID) | b64enc }}

--- a/cloud/helm/knowledgebase-slackbot/templates/openai-secret.yaml
+++ b/cloud/helm/knowledgebase-slackbot/templates/openai-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "knowledgebase-slackbot.openai-secret" . }}
-type: Opaque
-data:
-  api_key: {{ (required "OpenAI Token must be set" .Values.openaiToken) | b64enc }}

--- a/cloud/helm/knowledgebase-slackbot/templates/service-json-secret.yaml
+++ b/cloud/helm/knowledgebase-slackbot/templates/service-json-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "knowledgebase-slackbot.service-json-secret" . }}
-type: Opaque
-data:
-  service.json: |-
-    {{ .Files.Get "service.json" | b64enc }}
-

--- a/cloud/helm/knowledgebase-slackbot/templates/slackbot-tokens-secret.yaml
+++ b/cloud/helm/knowledgebase-slackbot/templates/slackbot-tokens-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "knowledgebase-slackbot.slackbot-tokens-secret" . }}
-type: Opaque
-data:
-  app-token: {{ (required "Slack APP Token must be set" .Values.slackAppToken) | b64enc }}
-  bot-token: {{ (required "Slack Bot Token must be set" .Values.slackBotToken) | b64enc }}

--- a/cloud/helm/knowledgebase-slackbot/templates/slackbot.yaml
+++ b/cloud/helm/knowledgebase-slackbot/templates/slackbot.yaml
@@ -16,8 +16,6 @@ spec:
       annotations:
         checksum/knowledgebase-config: {{ include (print $.Template.BasePath "/knowledgebase-configmap.yaml") . | sha256sum }}
         checksum/fluent-bit-config: {{ include (print $.Template.BasePath "/fluent-bit-configmap.yaml") . | sha256sum }}
-        checksum/slack-tokens: {{ include (print $.Template.BasePath "/slackbot-tokens-secret.yaml") . | sha256sum }}
-        checksum/slack-forward-channel: {{ include (print $.Template.BasePath "/forward-channel-secret.yaml") . | sha256sum }}
       labels:
         app: knowledgebase
         component: slackbot
@@ -25,7 +23,12 @@ spec:
       containers:
       - name: slackbot
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        command: ["python", "-m", "knowledge_base_gpt.apps.slackbot"]
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "--"
+        args:
+        - "source /vault-output/vars.env && python -m knowledge_base_gpt.apps.slackbot"
         volumeMounts:
         - mountPath: "/db"
           name: embedding
@@ -36,6 +39,9 @@ spec:
           name: knowledgebase-config
         - mountPath: /.cache
           name: cache
+        - name: vault-output
+          mountPath: /vault-output
+          readOnly: true
         env:
         - name: KNOWLEDGE_BASE_SETTINGS_FOLDER
           value: /etc/knowledgebase
@@ -44,26 +50,6 @@ spec:
             secretKeyRef:
               name: "{{ include "knowledgebase-slackbot.redis-password-secret" . }}"
               key: redis-password
-        - name: FORWARD_QUESTION_CHANNEL_NAME
-          valueFrom:
-            secretKeyRef:
-              name: "{{ include "knowledgebase-slackbot.forward-channel-secret" . }}"
-              key: channel
-        - name: SLACK_APP_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: "{{ include "knowledgebase-slackbot.slackbot-tokens-secret" . }}"
-              key: app-token
-        - name: SLACK_BOT_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: "{{ include "knowledgebase-slackbot.slackbot-tokens-secret" . }}"
-              key: bot-token
-        - name: OPENAI_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "{{ include "knowledgebase-slackbot.openai-secret" . }}"
-              key: api_key
         resources:
           limits:
             cpu: 1
@@ -98,6 +84,8 @@ spec:
           limits:
             cpu: 100m
             memory: 128Mi
+      initContainers:
+      {{- include "knowledgebase-slackbot.vault-init-container" . | nindent 6 }}
       volumes:
       - name: knowledgebase-config
         configMap:
@@ -114,3 +102,4 @@ spec:
       - name: fluent-bit-config
         configMap:
           name: {{ include "knowledgebase-slackbot.fluent-bit-config" . }}
+      {{- include "knowledgebase-slackbot.vault-volumes" (dict "root" . "configMapName" (include "knowledgebase-slackbot.vault-template-slackbot-configmap" .)) | nindent 6 }}

--- a/cloud/helm/knowledgebase-slackbot/templates/vault-agent-config.yml
+++ b/cloud/helm/knowledgebase-slackbot/templates/vault-agent-config.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "knowledgebase-slackbot.vault-agent-config-configmap" . }}
+data:
+  vault.hcl: |-
+{{ include "knowledgebase-slackbot.vault-agent-config" . | indent 4 }}

--- a/cloud/helm/knowledgebase-slackbot/templates/vault-template-ingest.yml
+++ b/cloud/helm/knowledgebase-slackbot/templates/vault-template-ingest.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "knowledgebase-slackbot.vault-template-ingest-configmap" . }}
+data:
+  vars.env.tmpl: |-
+{{ include "knowledgebase-slackbot.vault-template-ingest" . | indent 4 }}

--- a/cloud/helm/knowledgebase-slackbot/templates/vault-template-slackbot.yml
+++ b/cloud/helm/knowledgebase-slackbot/templates/vault-template-slackbot.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "knowledgebase-slackbot.vault-template-slackbot-configmap" . }}
+data:
+  vars.env.tmpl: |-
+{{ include "knowledgebase-slackbot.vault-template-slackbot" . | indent 4 }}

--- a/cloud/helm/knowledgebase-slackbot/templates/vault-template-vllm.yml
+++ b/cloud/helm/knowledgebase-slackbot/templates/vault-template-vllm.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "knowledgebase-slackbot.vault-template-vllm-configmap" . }}
+data:
+  vars.env.tmpl: |-
+{{ include "knowledgebase-slackbot.vault-template-vllm" . | indent 4 }}

--- a/cloud/helm/knowledgebase-slackbot/templates/vllm-deployment.yaml
+++ b/cloud/helm/knowledgebase-slackbot/templates/vllm-deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "knowledgebase-slackbot.vllm-deployment-name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm
+  template:
+    metadata:
+      labels:
+        app: vllm
+    spec:
+      containers:
+      - resources:
+          limits:
+            cpu: "1"
+            memory: "6Gi"
+            ephemeral-storage: "5Gi"
+            nvidia.com/gpu: "1"
+          requests:
+            cpu: "1"
+            memory: "6Gi"
+            ephemeral-storage: "5Gi"
+            nvidia.com/gpu: "1"
+        readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            timeoutSeconds: 5
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+        name: server
+        livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            timeoutSeconds: 8
+            periodSeconds: 100
+            successThreshold: 1
+            failureThreshold: 3
+        env:
+        - name: MODEL_ID
+          value: instructlab/granite-7b-lab
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "--"
+        args:
+        - "source /vault-output/vars.env && python3 -m vllm.entrypoints.openai.api_server --model=$(MODEL_ID) --download-dir=/models-cache --dtype=float16 --tensor-parallel-size=1 --api-key=$VLLM_APP_TOKEN"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+          timeoutSeconds: 1
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 24
+        volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: cache
+          mountPath: /models-cache
+        - name: vault-output
+          mountPath: /vault-output
+          readOnly: true
+        image: quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2
+      initContainers:
+      {{- include "knowledgebase-slackbot.vault-init-container" . | nindent 6 }}
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 1Gi
+      - name: cache
+        persistentVolumeClaim:
+          claimName: {{ include "knowledgebase-slackbot.vllm-pvc" . }}
+      {{- include "knowledgebase-slackbot.vault-volumes" (dict "root" . "configMapName" (include "knowledgebase-slackbot.vault-template-vllm-configmap" .)) | nindent 6 }}
+...

--- a/cloud/helm/knowledgebase-slackbot/templates/vllm-pvc.yaml
+++ b/cloud/helm/knowledgebase-slackbot/templates/vllm-pvc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "knowledgebase-slackbot.vllm-pvc" . }}
+  labels:
+    app: vllm
+    paas.redhat.com/appcode: CMPA-001
+  annotations:
+    kubernetes.io/reclaimPolicy: Delete
+spec:
+  storageClassName: aws-ebs
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/cloud/helm/knowledgebase-slackbot/templates/vllm-service.yaml
+++ b/cloud/helm/knowledgebase-slackbot/templates/vllm-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm
+spec:
+  selector:
+    app: vllm
+  type: ClusterIP
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8000
+      targetPort: http
+...

--- a/cloud/helm/knowledgebase-slackbot/values.yaml
+++ b/cloud/helm/knowledgebase-slackbot/values.yaml
@@ -55,20 +55,8 @@ affinity: {}
 # Embedding Volume Parameters
 embeddingVolumeSize: 2Gi
 
-# Google Folder ID to ingest
-ingestFolderID: ""
-
 # Metrics Volume Parameters
 logsVolumeSize: 1Gi
-
-# Slack Channel to forward unanswered conversations
-forwardChannel: ""
-
-# Slack App and Bot tokens
-slackAppToken: ""
-slackBotToken: ""
-
-openaiToken: ""
 
 fluentbitImageTag: "2.2"
 
@@ -76,6 +64,11 @@ logrotate:
   imageTag: latest
   size: 1M
   interval: hourly
+
+# Name of the config map holding the Vault server address (under address) and CA Token (under ca.crt)
+vaultServerConfigMap: ""
+# Name of the secret holding the credentials to the Vault server (role-id and secret-id)
+vaultCredentialsSecret: ""
 
 redis:
   architecture: standalone

--- a/tests/helmlint/dummy-values.yml
+++ b/tests/helmlint/dummy-values.yml
@@ -1,7 +1,2 @@
-certificateIssuer: dummy-ca-issuer
-ingestFolderID: dummy-folder-id
-forwardChannel: dummy-channel
-slackAppToken: xapp-dummy
-slackBotToken: xoxb-dummy
-ollamaServerAddress: dummy.example.com
-openaiToken: dummy-openai-token
+vaultServerConfigMap: "dummy-vault-server-details"
+vaultCredentialsSecret: "dummy-vault-server-credentials"


### PR DESCRIPTION
Add deployment for vLLM
Add vault agent initContainer to the deployments and jobs Remove unused secrets
Remove unused values
Add vault server related values
Add jq to the container
Bump container version
Update README