### PR TITLE
Replace the fedora base image with ubi9

### DIFF
--- a/knowledge_base_gpt/libs/vectorstore/vectorstore.py
+++ b/knowledge_base_gpt/libs/vectorstore/vectorstore.py
@@ -1,20 +1,25 @@
 """ Module to create and abstract the actual vector store based on the configuration """
 from injector import inject, singleton
-from chromadb.config import Settings as ChromaSettings
-from langchain_community.vectorstores.chroma import Chroma
 
 from knowledge_base_gpt.libs.embedding.embedding import Embedding
 from knowledge_base_gpt.libs.settings.settings import Settings
 
 
 @singleton
-class VectorStore():  # pylint:disable=R0903
+class VectorStore():  # pylint:disable=R0903,C0415
     """ Abstract the actual vector store based on the configuration """
     @inject
     def __init__(self, settings: Settings, embedding: Embedding) -> None:
         mode = settings.vectorstore.mode
         match mode:
             case 'chroma':
+                # Override the sqlite3 module with pysqlite3 which used a newer version of SQLite
+                import sys
+                sys.modules['sqlite3'] = __import__('pysqlite3')
+
+                from chromadb.config import Settings as ChromaSettings
+                from langchain_community.vectorstores.chroma import Chroma
+
                 self._db = Chroma(
                     persist_directory=settings.vectorstore.persist_directory,
                     embedding_function=embedding.embeddings,

--- a/poetry.lock
+++ b/poetry.lock
@@ -2014,7 +2014,6 @@ description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
-    {file = "nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4abe7fef64914ccfa909bc2ba39739670ecc9e820c83ccc7a6ed414122599b83"},
     {file = "nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:06b3b9b25bf3f8af351d664978ca26a16d2c5127dbd53c0497e28d1fb9611d57"},
     {file = "nvidia_nvjitlink_cu12-12.4.127-py3-none-win_amd64.whl", hash = "sha256:fd9020c501d27d135f983c6d3e244b197a7ccad769e34df53a42e276b0e25fa1"},
 ]
@@ -2711,6 +2710,22 @@ files = [
 ]
 
 [[package]]
+name = "pysqlite3-binary"
+version = "0.5.3"
+description = "DB-API 2.0 interface for Sqlite 3.x"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pysqlite3_binary-0.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad8325f9b74e94fa542678fd30ac8b53dc25a5bd9e88b41151a62127f870ed7f"},
+    {file = "pysqlite3_binary-0.5.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:002fcba03fdd5ad190b9438a1c5c648ae8a4d6992d3d54daec2ab8138b1a4183"},
+    {file = "pysqlite3_binary-0.5.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58992010c654b81b403b0175cfa32f499de5cb3a4e4e53c9eb9fb44d66370a84"},
+    {file = "pysqlite3_binary-0.5.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b21717b4df66b3b3f759f31209b1c835edfa1ad7768f7b2847337382b6c6003f"},
+    {file = "pysqlite3_binary-0.5.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:763381e59ce70344d7e1a621b41069a1364e9a05c07103579af88e775952852b"},
+    {file = "pysqlite3_binary-0.5.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68ac693470e361ff0a63a25c6be3354c784d6b0c2cdc7c2a9e8a956be6c8693a"},
+    {file = "pysqlite3_binary-0.5.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b672326ec8eacd40cd9d31959f477fca6bbcc32d0e2b115ce1c00882a9afc7a"},
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2763,7 +2778,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4297,4 +4311,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5b0dd5e204f0d947b4ebf1eda88837c8df5cab2e26f89219404ab9189e2c207f"
+content-hash = "b506a73f5279158b11bcfdf03eaafe852ad83c5708d1e16cda166a125f044107"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ sentence-transformers = "^3.0.0"
 langchain-openai = "^0.1.3"
 langchain-huggingface = "^0.0.3"
 langchain-google-community = "^1.0.5"
+pysqlite3-binary = "^0.5.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sentence-transformers==3.0.1
 langchain-openai==0.1.9
 langchain-huggingface==0.0.3
 langchain-google-community==1.0.5
+pysqlite3-binary==0.5.3


### PR DESCRIPTION
Replace Development Tools with specific packages
Install python3.11 in both the build and runtime containers
Since UBI9 uses an old version of sqlite, add pysqlite3-binary and use it instead
Set user ID for the container