### PR TITLE
Allow overriding the base_url of the Slack server

### DIFF
--- a/knowledge_base_gpt/libs/settings/settings.py
+++ b/knowledge_base_gpt/libs/settings/settings.py
@@ -18,6 +18,10 @@ class SlackBotSettings(BaseModel):
     forward_channel: str = Field(
         description="Name of the channel to forward unresolved conversations to"
     )
+    base_url: str = Field(
+        "",
+        description="Base URL of the Slack server - used for testing"
+    )
 
 
 class LLMSettings(BaseModel):


### PR DESCRIPTION
Used to testing
Add a settings entry
If set, pass the base_url to the slack WebClient